### PR TITLE
Fix substring for .Net Standard

### DIFF
--- a/Solidsoft.Reply.Parsers.Gs1Ai/EntityResolver.cs
+++ b/Solidsoft.Reply.Parsers.Gs1Ai/EntityResolver.cs
@@ -4057,7 +4057,7 @@ internal static class EntityResolver {
 #if NET6_0_OR_GREATER
                     data[..length],
 #else
-                    data.Substring(length),
+                    data.Substring(0, length),
 #endif
                     true,
                     out ApplicationIdentifier applicationIdentifier)
@@ -4191,7 +4191,7 @@ internal static class EntityResolver {
 #if NET6_0_OR_GREATER
                 data[startIndex..(length + startIndex)],
 #else
-                data.Substring(startIndex, length + startIndex - 1),
+                data.Substring(startIndex, length),
 #endif
                 out var number)
             && number.IsNumberInRange(lowerBound, upperBound);


### PR DESCRIPTION
The Substring() used for .NET standard does not match the range operator used for .NET >=6

Therefore, three-digit AI's are not recognised.